### PR TITLE
searching on the first two characters is a resource drain

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -19,10 +19,10 @@ $( document ).delegate("#cm-contact-form", "pageinit", function() {
 // events for contact search
 $( document ).delegate("#cm-contact-search", "pageinit", function() {
   $('#sort_name').keyup( function() {
-    if ($(this).val()) {
+    if ($(this).val().length > 2) {
       contactSearch($(this).val());
     }
-    else {
+    else if (!$(this).val()) {
       $('#contacts').empty();
     }
   });


### PR DESCRIPTION
All you need is 4 or 5 people using this interface at the same
time and it can bring the sql server to it's knees, particularly
if people are slow typists. This patch requires there to be at least
three characters before it does a search.
