### PR TITLE
civimobile.header.php: use getUrl() for includePath

### DIFF
--- a/code/civimobile.header.php
+++ b/code/civimobile.header.php
@@ -15,7 +15,7 @@ $session =& CRM_Core_Session::singleton();
 $civimobile_vars['loggedInContactID'] = $session->get('userID');
 
 // extension include path
-$includePath = $config->extensionsURL . DIRECTORY_SEPARATOR . 'com.webaccessglobal.module.civimobile' . DIRECTORY_SEPARATOR;
+$includePath = CRM_Core_Resources::singleton()->getUrl('com.webaccessglobal.module.civimobile') . DIRECTORY_SEPARATOR;
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">


### PR DESCRIPTION
The extension assumes that extensions are all in the same directory. In multi-site setups, I put vendor extensions in `/vendor/civicrm` (at the Drupal root), and site-specific extensions in `/sites/example.org/extensions/`.

This PR fixes that by using `CRM_Core_Resources::singleton()->getUrl()` instead of  `$config->extensionsURL`.